### PR TITLE
Add /kata and /podcasts to urls in coderdojo.json

### DIFF
--- a/configs/coderdojo.json
+++ b/configs/coderdojo.json
@@ -1,7 +1,9 @@
 {
   "index_name": "coderdojo",
   "start_urls": [
-    "https://coderdojo.jp/docs/"
+    "https://coderdojo.jp/docs/",
+    "https://coderdojo.jp/kata",
+    "https://coderdojo.jp/podcasts"
   ],
   "sitemap_urls": [
     "https://coderdojo.jp/sitemap.xml"


### PR DESCRIPTION
CoderDojo Japan's website now has a wiki page (/kata)
and podcasting pages (/podcasts) in addition to /docs.
So add them to start_urls in coderdojo.json to be indexed.
